### PR TITLE
Handle case where pointer to undef is returned from perl

### DIFF
--- a/php_perl.c
+++ b/php_perl.c
@@ -597,6 +597,8 @@ static zval* php_perl_sv_to_zval_noref(PerlInterpreter *my_perl,
         add_assoc_zval_ex(zv, key, key_len+1,
           php_perl_sv_to_zval_ref(my_perl, el_sv, NULL, var_hash TSRMLS_CC));
       }
+    } else if (SvTYPE(sv) == SVt_PVIV && !SvOK(sv)) { /* pointer to undef? */
+      ZVAL_NULL(zv);
     } else {
       zend_error(E_ERROR, "[perl] Can't convert Perl type (%ld) to PHP",
                  SvTYPE(sv));


### PR DESCRIPTION
theoretically, `SvIOK` and `SvPOK` checks mean that the `&& !SvOK` check may not be required as a defined PVIV has already been handled. Also theoretically, it should be safe to return `null` for _any_ `!SvOK` check even if we don't know SvTYPE. That said, I don't really understand well enough to be sure so I'm sticking to the situation I actually have witnessed in the wild.